### PR TITLE
Add -fPIC to compilation options.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all: libnss_etcd.so.2
 
 libnss_etcd.so.2: nssrc.c
-	gcc -shared -o libnss_etcd.so.2 -Wl,-soname,libnss_etcd.so.2 nssrc.c
+	gcc -shared -fPIC -o libnss_etcd.so.2 -Wl,-soname,libnss_etcd.so.2 nssrc.c


### PR DESCRIPTION
PIC is Position Independent Code, and is important for libraries.

I needed this to compile on Arch with gcc 4.9.2.
